### PR TITLE
:sparkles: feat: create function to only create topic in service with…

### DIFF
--- a/backend/app/services/topic_service.py
+++ b/backend/app/services/topic_service.py
@@ -25,6 +25,18 @@ class TopicService:
                 raise
         attached = self.users_topics.attach(user_id, created.id)
         return {"topic": created, "attached": attached}
+    
+    def create_topic(self, data: dict) -> Topic:
+        name = (data or {}).get("name")
+        state = (data or {}).get("state", 1)
+        topic = Topic(name=name, state=state)
+        try:
+            created = self.topics.create(topic)
+        except IntegrityError:
+            created = self.topics.find_by_name(topic.name) or None
+            if not created:
+                raise
+        return {"topic": created}
 
     def find_by_user(self, user_id: int):
         ids = self.users_topics.list_user_topic_ids(user_id)


### PR DESCRIPTION
# Criação dos endpoints de tópicos

Este tópico rastreia as mudanças implementadas para permitir adicionar, remover e vincular tópicos de interesse ao perfil, conforme os critérios de aceitação da HU003.8.

## Escopo entregue
- Modelagem das tabelas: `topics` e `user_topics`.
- Criação dos endpoints REST de criação, listagem, vínculo e remoção.
- Vínculo dos tópicos aos usuários autenticados.

## Modelagem de dados
- `topics`: `id`, `name`, `state`, `created_at`.
- `user_topics`: `id`, `user_id`, `topic_id`, `created_at`.

## Endpoints

### Criar tópico e vinculo automatico ao usuario logado
- Método/rota: `POST` /topics/create`
- Body: `{ "name": "Tecnologia", "state": "1" }`
- Respostas:
  - 201 Created: `{ "id": 1, "name": "Tecnologia", "state": "1" }`

### Listar tópicos (com busca)
- Método/rota: `GET` /topics/list
- Respostas:
  - 200 OK: `{ "items": [ { "id": 1, "name": "Tecnologia", "state": "1" } ], "page": 1, "pageSize": 20, "total": 1 }`

