### PR TITLE
Final tests implementations

### DIFF
--- a/backend/tests/test_news_source_controller.py
+++ b/backend/tests/test_news_source_controller.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from flask import Flask, jsonify
+from sqlalchemy.exc import IntegrityError
+from app.controllers.news_source_controller import NewsSourceController
+from app.models.news_source import NewsSource
+from app.models.exceptions import NewsSourceNotFoundError, NewsSourceAlreadyAttachedError, NewsSourceNotAttachedError
+
+@pytest.fixture
+def mock_service():
+    with patch('app.controllers.news_source_controller.NewsSourceService') as mock:
+        yield mock.return_value
+
+@pytest.fixture
+def app_context():
+    app = Flask(__name__)
+    with app.app_context():
+        yield
+
+@pytest.fixture
+def controller(mock_service, app_context):
+    c = NewsSourceController()
+    c.service = mock_service
+    return c
+
+def test_list_all_success(controller, mock_service):
+    sources = [NewsSource(id=1, name="Test Source", url="http://test.com")]
+    mock_service.list_all.return_value = sources
+    response, status_code = controller.list_all()
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_exception(controller, mock_service):
+    mock_service.list_all.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all()
+    assert status_code == 500
+    assert response.json["success"] is False
+    assert "Erro interno do servidor" in response.json["message"]
+
+def test_list_all_unattached_success(controller, mock_service):
+    user_id = 1
+    sources = [NewsSource(id=2, name="Unattached", url="http://unattached.com")]
+    mock_service.list_unassociated_by_user_id.return_value = sources
+    response, status_code = controller.list_all_unattached_news_sources(user_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_unattached_exception(controller, mock_service):
+    user_id = 1
+    mock_service.list_unassociated_by_user_id.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all_unattached_news_sources(user_id)
+    assert status_code == 500
+    assert response.json["success"] is False
+
+def test_list_all_attached_success(controller, mock_service):
+    user_id = 1
+    sources = [NewsSource(id=3, name="Attached", url="http://attached.com")]
+    mock_service.list_by_user_id.return_value = sources
+    response, status_code = controller.list_all_attached_sources(user_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_attached_exception(controller, mock_service):
+    user_id = 1
+    mock_service.list_by_user_id.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all_attached_sources(user_id)
+    assert status_code == 500
+    assert response.json["success"] is False
+
+def test_attach_success(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.return_value = None
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 200
+    assert response.json["success"] is True
+    mock_service.attach_source_to_user.assert_called_once_with(user_id, 10)
+
+def test_attach_missing_source_id(controller):
+    user_id = 1
+    data = {}
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "source_id é obrigatório" in response.json["error"]
+
+def test_attach_invalid_source_id(controller):
+    user_id = 1
+    data = {"source_id": "abc"}
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "deve ser um número inteiro válido" in response.json["error"]
+
+def test_attach_source_not_found(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 999}
+    mock_service.attach_source_to_user.side_effect = NewsSourceNotFoundError("Not Found")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 404
+    assert "Not Found" in response.json["error"]
+
+def test_attach_already_attached(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = NewsSourceAlreadyAttachedError("Conflict")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 409
+    assert "Conflict" in response.json["error"]
+
+def test_attach_integrity_error(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = IntegrityError(None, None, None)
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "Falha de integridade" in response.json["message"]
+
+def test_attach_generic_exception(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = Exception("Generic Error")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 500
+    assert "Erro interno do servidor" in response.json["message"]
+
+def test_detach_success(controller, mock_service):
+    user_id = 1
+    source_id = 10
+    mock_service.detach_source_from_user.return_value = None
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    mock_service.detach_source_from_user.assert_called_once_with(user_id, source_id)
+
+def test_detach_not_attached(controller, mock_service):
+    user_id = 1
+    source_id = 999
+    mock_service.detach_source_from_user.side_effect = NewsSourceNotAttachedError("Not Found")
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 404
+    assert "Not Found" in response.json["error"]
+
+def test_detach_generic_exception(controller, mock_service):
+    user_id = 1
+    source_id = 10
+    mock_service.detach_source_from_user.side_effect = Exception("Generic Error")
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 500
+    assert "Erro interno do servidor" in response.json["message"]

--- a/backend/tests/test_news_source_integration.py
+++ b/backend/tests/test_news_source_integration.py
@@ -1,0 +1,136 @@
+import pytest
+from flask.testing import FlaskClient
+from app.models.user import User
+from app.models.news_source import NewsSource
+from app.entities.user_news_sources_entity import UserNewsSourceEntity
+
+def test_add_source_to_user_success(client: FlaskClient, db):
+    user_model = User(full_name="Test User", email="sourceuser@example.com", password="Password123")
+    source_model = NewsSource(name="New Source", url="http://newsource.com")
+    
+    user_entity = user_model.to_orm()
+    source_entity = source_model.to_orm()
+    db.session.add_all([user_entity, source_entity])
+    db.session.commit()
+
+    login_res = client.post("/users/login", json={"email": "sourceuser@example.com", "password": "Password123"})
+    assert login_res.status_code == 200
+
+    auth_client, headers = get_auth_client(client, {"email": "sourceuser@example.com", "password": "Password123"})
+
+    add_source_res = auth_client.post(
+        "/news_sources/attach", 
+        json={"source_id": source_entity.id},
+        headers=headers
+    )
+    assert add_source_res.status_code == 200
+    assert add_source_res.json["success"] is True
+    assert "Fonte associada com sucesso." in add_source_res.json["message"]
+
+    association = db.session.query(UserNewsSourceEntity).filter_by(user_id=user_entity.id, source_id=source_entity.id).first()
+    assert association is not None
+
+def test_add_existing_source_to_user(client: FlaskClient, db):
+    user_model = User(full_name="Another User", email="anotheruser@example.com", password="Password123")
+    source_model = NewsSource(name="Existing Source", url="http://existingsource.com")
+
+    user_entity = user_model.to_orm()
+    source_entity = source_model.to_orm()
+    db.session.add_all([user_entity, source_entity])
+    db.session.commit()
+
+    auth_client, headers = get_auth_client(client, {"email": "anotheruser@example.com", "password": "Password123"})
+
+    add_source_res = auth_client.post(
+        "/news_sources/attach", 
+        json={"source_id": source_entity.id},
+        headers=headers
+    )
+    assert add_source_res.status_code == 200
+    assert add_source_res.json["success"] is True
+
+def test_add_source_missing_fields(client: FlaskClient, db):
+    user_model = User(full_name="Test User 3", email="user3@example.com", password="Password123")
+    user_entity = user_model.to_orm()
+    db.session.add(user_entity)
+    db.session.commit()
+    
+    auth_client, headers = get_auth_client(client, {"email": "user3@example.com", "password": "Password123"})
+
+    add_source_res = auth_client.post(
+        "/news_sources/attach", 
+        json={},
+        headers=headers
+    )
+    assert add_source_res.status_code == 400
+    assert "source_id é obrigatório." in add_source_res.json["error"]
+
+def test_list_user_sources(client: FlaskClient, db):
+    user_model = User(full_name="List User", email="listuser@example.com", password="Password123")
+    source1_model = NewsSource(name="Source One", url="http://sourceone.com")
+    source2_model = NewsSource(name="Source Two", url="http://sourcetwo.com")
+
+    user_entity = user_model.to_orm()
+    source1_entity = source1_model.to_orm()
+    source2_entity = source2_model.to_orm()
+    db.session.add_all([user_entity, source1_entity, source2_entity])
+    db.session.commit()
+
+    db.session.add(UserNewsSourceEntity(user_id=user_entity.id, source_id=source1_entity.id))
+    db.session.add(UserNewsSourceEntity(user_id=user_entity.id, source_id=source2_entity.id))
+    db.session.commit()
+
+    auth_client, _ = get_auth_client(client, {"email": "listuser@example.com", "password": "Password123"})
+
+    list_res = auth_client.get("/news_sources/list_all_attached_sources")
+    assert list_res.status_code == 200
+    data = list_res.json["data"]
+    assert len(data) == 2
+    assert {item['name'] for item in data} == {"Source One", "Source Two"}
+
+def test_remove_source_from_user(client: FlaskClient, db):
+    user_model = User(full_name="Remove User", email="removeuser@example.com", password="Password123")
+    source_model = NewsSource(name="Removable Source", url="http://removable.com")
+    user_entity = user_model.to_orm()
+    source_entity = source_model.to_orm()
+    db.session.add_all([user_entity, source_entity])
+    db.session.commit()
+    db.session.add(UserNewsSourceEntity(user_id=user_entity.id, source_id=source_entity.id))
+    db.session.commit()
+
+    auth_client, headers = get_auth_client(client, {"email": "removeuser@example.com", "password": "Password123"})
+
+    remove_res = auth_client.delete(f"/news_sources/detach/{source_entity.id}", headers=headers)
+    assert remove_res.status_code == 200
+    assert "Fonte desassociada com sucesso." in remove_res.json["message"]
+
+def test_remove_non_existent_source(client: FlaskClient, db):
+    user_model = User(full_name="Remove User 2", email="removeuser2@example.com", password="Password123")
+    user_entity = user_model.to_orm()
+    db.session.add(user_entity)
+    db.session.commit()
+    
+    auth_client, headers = get_auth_client(client, {"email": "removeuser2@example.com", "password": "Password123"})
+
+    remove_res = auth_client.delete("/news_sources/detach/999", headers=headers)
+    assert remove_res.status_code == 404
+    assert "Associação não encontrada para ser removida." in remove_res.json["error"]
+
+def get_auth_client(client, user_data):
+    login_data = {
+        "email": user_data["email"],
+        "password": user_data["password"]
+    }
+
+    client.post(
+        '/users/login',
+        json=login_data,
+    )
+ 
+    csrf_cookie = client.get_cookie('csrf_access_token')
+    csrf_token = ""
+    if csrf_cookie:
+        csrf_token = csrf_cookie.value
+ 
+    headers = {'X-CSRF-TOKEN': csrf_token}
+    return client, headers

--- a/backend/tests/test_news_source_repository.py
+++ b/backend/tests/test_news_source_repository.py
@@ -1,0 +1,84 @@
+import pytest
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from unittest.mock import patch
+from app.repositories.news_source_repository import NewsSourceRepository
+from app.models.news_source import NewsSource
+from app.entities.user_entity import UserEntity
+from app.entities.news_source_entity import NewsSourceEntity
+from app.entities.user_news_sources_entity import UserNewsSourceEntity
+
+@pytest.fixture
+def news_source_repo(db):
+    return NewsSourceRepository(session=db.session)
+
+def test_create_news_source_success(news_source_repo):
+    source_model = NewsSource(name="Test Source", url="http://testsource.com")
+    created_source = news_source_repo.create(source_model)
+    assert created_source.id is not None
+    assert created_source.name == "Test Source"
+
+def test_create_duplicate_url_fails(news_source_repo):
+    source1 = NewsSource(name="Source One", url="http://duplicate.com")
+    news_source_repo.create(source1)
+    source2 = NewsSource(name="Source Two", url="http://duplicate.com")
+    with pytest.raises(IntegrityError):
+        news_source_repo.create(source2)
+
+def test_find_by_id(news_source_repo, db):
+    source_entity = NewsSourceEntity(name="Find Me", url="http://findme.com")
+    db.session.add(source_entity)
+    db.session.commit()
+    found = news_source_repo.find_by_id(source_entity.id)
+    assert found is not None
+    assert found.id == source_entity.id
+
+def test_find_by_url(news_source_repo, db):
+    source_entity = NewsSourceEntity(name="Find By URL", url="http://findbyurl.com")
+    db.session.add(source_entity)
+    db.session.commit()
+    found = news_source_repo.find_by_url("http://findbyurl.com")
+    assert found is not None
+    assert found.url == "http://findbyurl.com"
+
+def test_list_all(news_source_repo, db):
+    db.session.add(NewsSourceEntity(name="A", url="http://a.com"))
+    db.session.add(NewsSourceEntity(name="B", url="http://b.com"))
+    db.session.commit()
+    sources = news_source_repo.list_all()
+    assert len(sources) == 2
+
+def test_list_by_user_id(news_source_repo, db):
+    user = UserEntity(full_name="Test User", email="user@test.com")
+    user.password_hash = "hash"
+    s1 = NewsSourceEntity(name="S1", url="http://s1.com")
+    s2 = NewsSourceEntity(name="S2", url="http://s2.com")
+    db.session.add_all([user, s1, s2])
+    db.session.commit()
+    db.session.add(UserNewsSourceEntity(user_id=user.id, source_id=s1.id))
+    db.session.commit()
+    
+    user_sources = news_source_repo.list_by_user_id(user.id)
+    assert len(user_sources) == 1
+    assert user_sources[0].name == "S1"
+
+def test_list_unassociated_by_user_id(news_source_repo, db):
+    user = UserEntity(full_name="Test User 2", email="user2@test.com")
+    user.password_hash = "hash"
+    s1 = NewsSourceEntity(name="S1-un", url="http://s1un.com")
+    s2 = NewsSourceEntity(name="S2-un", url="http://s2un.com") 
+    s3 = NewsSourceEntity(name="S3-un", url="http://s3un.com") 
+    db.session.add_all([user, s1, s2, s3])
+    db.session.commit()
+    db.session.add(UserNewsSourceEntity(user_id=user.id, source_id=s1.id))
+    db.session.commit()
+
+    unassociated = news_source_repo.list_unassociated_by_user_id(user.id)
+    assert len(unassociated) == 2
+    names = {s.name for s in unassociated}
+    assert "S2-un" in names
+    assert "S3-un" in names
+
+def test_sqlalchemy_error_on_list(news_source_repo):
+    with patch.object(news_source_repo.session, 'execute', side_effect=SQLAlchemyError("DB Error")):
+        with pytest.raises(SQLAlchemyError):
+            news_source_repo.list_all()

--- a/backend/tests/test_news_source_unit.py
+++ b/backend/tests/test_news_source_unit.py
@@ -1,0 +1,123 @@
+import pytest
+from unittest.mock import MagicMock
+from app.services.news_source_service import NewsSourceService
+from app.models.news_source import NewsSource
+from app.models.exceptions import NewsSourceValidationError, NewsSourceNotFoundError, NewsSourceAlreadyAttachedError
+from sqlalchemy.exc import IntegrityError
+
+
+@pytest.fixture
+def mock_news_source_repository():
+    return MagicMock()
+
+@pytest.fixture
+def mock_user_news_source_repository():
+    return MagicMock()
+
+@pytest.fixture
+def news_source_service(mock_news_source_repository, mock_user_news_source_repository):
+    return NewsSourceService(
+        repo=mock_news_source_repository,
+        user_source_repo=mock_user_news_source_repository
+    )
+
+def test_attach_source_to_user_success(news_source_service, mock_news_source_repository, mock_user_news_source_repository):
+    user_id = 1
+    source_id = 10
+    mock_news_source_repository.find_by_id.return_value = NewsSource(id=source_id, name="Test", url="http://test.com")
+
+    news_source_service.attach_source_to_user(user_id, source_id)
+
+    mock_news_source_repository.find_by_id.assert_called_once_with(source_id)
+    mock_user_news_source_repository.attach.assert_called_once_with(user_id, source_id)
+
+def test_attach_source_to_user_source_not_found(news_source_service, mock_news_source_repository):
+    user_id = 1
+    source_id = 999
+    mock_news_source_repository.find_by_id.return_value = None
+
+    with pytest.raises(NewsSourceNotFoundError):
+        news_source_service.attach_source_to_user(user_id, source_id)
+
+def test_attach_source_to_user_integrity_error(news_source_service, mock_news_source_repository, mock_user_news_source_repository):
+    user_id = 1
+    source_id = 10
+    mock_news_source_repository.find_by_id.return_value = NewsSource(id=source_id, name="Test", url="http://test.com")
+    mock_user_news_source_repository.attach.side_effect = IntegrityError(None, None, None)
+
+    with pytest.raises(IntegrityError):
+        news_source_service.attach_source_to_user(user_id, source_id)
+
+def test_attach_source_to_user_already_attached(news_source_service, mock_news_source_repository, mock_user_news_source_repository):
+    user_id = 1
+    source_id = 10
+    mock_news_source_repository.find_by_id.return_value = NewsSource(id=source_id, name="Test", url="http://test.com")
+    mock_user_news_source_repository.attach.side_effect = NewsSourceAlreadyAttachedError("Already attached")
+
+    with pytest.raises(NewsSourceAlreadyAttachedError):
+        news_source_service.attach_source_to_user(user_id, source_id)
+
+
+def test_list_sources_by_user(news_source_service, mock_news_source_repository):
+    user_id = 1
+    sources = [NewsSource(id=1, name="A", url="http://a.com"), NewsSource(id=2, name="B", url="http://b.com")]
+    mock_news_source_repository.list_by_user_id.return_value = sources
+
+    result = news_source_service.list_by_user_id(user_id)
+    
+    assert len(result) == 2
+    mock_news_source_repository.list_by_user_id.assert_called_once_with(user_id)
+
+def test_list_all_sources(news_source_service, mock_news_source_repository):
+    sources = [NewsSource(id=1, name="A", url="http://a.com"), NewsSource(id=2, name="B", url="http://b.com")]
+    mock_news_source_repository.list_all.return_value = sources
+
+    result = news_source_service.list_all()
+
+    assert len(result) == 2
+    mock_news_source_repository.list_all.assert_called_once()
+
+def test_list_unassociated_by_user_id(news_source_service, mock_news_source_repository):
+    user_id = 1
+    sources = [NewsSource(id=3, name="C", url="http://c.com")]
+    mock_news_source_repository.list_unassociated_by_user_id.return_value = sources
+
+    result = news_source_service.list_unassociated_by_user_id(user_id)
+
+    assert len(result) == 1
+    assert result[0].name == "C"
+    mock_news_source_repository.list_unassociated_by_user_id.assert_called_once_with(user_id)
+
+
+def test_detach_source_from_user(news_source_service, mock_user_news_source_repository):
+    user_id = 1
+    source_id = 10
+
+    news_source_service.detach_source_from_user(user_id, source_id)
+
+    mock_user_news_source_repository.detach.assert_called_once_with(user_id, source_id)
+
+def test_news_source_model_validation():
+    with pytest.raises(NewsSourceValidationError, match="name: não pode ser vazio."):
+        NewsSource(name="", url="http://valid.com")
+    with pytest.raises(NewsSourceValidationError, match="url: não pode ser vazia."):
+        NewsSource(name="Valid Name", url="")
+    with pytest.raises(NewsSourceValidationError, match="url: formato inválido."):
+        NewsSource(name="Valid Name", url="not-a-url")
+
+def test_list_all_sources_exception(news_source_service, mock_news_source_repository):
+    mock_news_source_repository.list_all.side_effect = Exception("DB Error")
+    with pytest.raises(Exception, match="DB Error"):
+        news_source_service.list_all()
+
+def test_list_unassociated_by_user_id_exception(news_source_service, mock_news_source_repository):
+    user_id = 1
+    mock_news_source_repository.list_unassociated_by_user_id.side_effect = Exception("DB Error")
+    with pytest.raises(Exception, match="DB Error"):
+        news_source_service.list_unassociated_by_user_id(user_id)
+
+def test_list_by_user_id_exception(news_source_service, mock_news_source_repository):
+    user_id = 1
+    mock_news_source_repository.list_by_user_id.side_effect = Exception("DB Error")
+    with pytest.raises(Exception, match="DB Error"):
+        news_source_service.list_by_user_id(user_id)

--- a/backend/tests/test_topic_controller.py
+++ b/backend/tests/test_topic_controller.py
@@ -13,7 +13,6 @@ def mock_service():
 
 @pytest.fixture
 def app_context():
-    """Pushes an application context for the duration of the test."""
     app = Flask(__name__)
     with app.app_context():
         yield

--- a/backend/tests/test_topic_routes.py
+++ b/backend/tests/test_topic_routes.py
@@ -11,7 +11,6 @@ valid_user_data = {
 }
 
 def get_auth_client(client, user_data):
-    # Register user via API to ensure it exists for login
     client.post('/users/register', data=json.dumps(user_data), content_type='application/json')
  
     login_data = {
@@ -91,8 +90,7 @@ def test_add_topic_to_user_without_name_fails(client, db):
 
 def test_get_user_topics_successfully(client, db):
     auth_client, headers = get_auth_client(client, valid_user_data)
-
-    # Add topics for the user via the API
+    
     auth_client.post('/topics/create', data=json.dumps({"name": "saúde"}), content_type='application/json', headers=headers)
     auth_client.post('/topics/create', data=json.dumps({"name": "economia"}), content_type='application/json', headers=headers)
 
@@ -121,8 +119,7 @@ def test_remove_topic_from_user_successfully(client, db):
     topic = Topic(name="arte").to_orm()
     db.session.add(topic)
     db.session.flush()
-
-    # Associate topic with user (user_id=1 because it's the first one created)
+    
     user_topic = UserTopicEntity(user_id=1, topic_id=topic.id)
     db.session.add(user_topic)
     db.session.commit()
@@ -133,7 +130,6 @@ def test_remove_topic_from_user_successfully(client, db):
     assert data['success'] is True
     assert "Tópico desvinculado com sucesso." in data['message']
 
-    # Verify it was deleted from the association table
     association = db.session.query(UserTopicEntity).filter_by(user_id=1, topic_id=topic.id).first()
     assert association is None
 
@@ -146,7 +142,7 @@ def test_remove_nonexistent_topic_from_user_fails(client, db):
     assert "Nada a remover." in error_data['error']
 
 def test_topic_routes_without_token_fails(client):
-    response = client.get('/topics/list') # GET requests don't need CSRF header, just the cookie
+    response = client.get('/topics/list') 
     assert response.status_code == 401
 
     response = client.post(

--- a/backend/tests/test_user_controller.py
+++ b/backend/tests/test_user_controller.py
@@ -1,166 +1,160 @@
-import json
 import pytest
 from unittest.mock import patch, MagicMock
+from flask import Flask
+from flask_jwt_extended import JWTManager
 from app.controllers.user_controller import UserController
 from app.models.exceptions import (
     UserValidationError,
-    EmailInUseError,
     UserNotFoundError,
+    EmailInUseError,
     InvalidPasswordError
 )
-from sqlalchemy.exc import IntegrityError
-from flask import Flask
-from flask_jwt_extended import JWTManager
 
 class AttrDict(dict):
-    """
-    Uma classe de dicionário que também permite o acesso a chaves como atributos.
-    """
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def app_context():
     app = Flask(__name__)
     app.config["JWT_SECRET_KEY"] = "super-secret-test-key"
     JWTManager(app)
-    with app.test_request_context():
+    with app.app_context():
         yield
 
 @pytest.fixture
 def mock_service():
-    with patch('app.controllers.user_controller.UserService') as MockUserService:
-        yield MockUserService.return_value
+    with patch('app.controllers.user_controller.UserService') as mock:
+        yield mock.return_value
 
 @pytest.fixture
-def user_controller(mock_service):
+def controller(mock_service, app_context):
     controller = UserController()
     controller.service = mock_service
     return controller
 
-# --- Testes de Registro ---
+def test_register_success(controller, mock_service):
+    data = {"full_name": "Test User", "email": "test@example.com", "password": "password123"}
 
-def test_register_key_error_returns_400(user_controller, mock_service):
-    # Simulamos o serviço levantando o erro que o controller deve tratar
+    mock_user = MagicMock()
+    mock_user.to_dict.return_value = {"id": 1, "email": data["email"], "full_name": data["full_name"]}
+    mock_service.register.return_value = mock_user 
+
+    response, status_code = controller.register(data)
+    json_data = response.get_json()
+
+    assert status_code == 201
+    assert json_data["success"] is True
+    assert json_data["message"] == "Usuário registrado com sucesso."
+    assert json_data["data"] is None
+    assert json_data["error"] is None
+
+def test_register_key_error_returns_400(controller, mock_service):
     mock_service.register.side_effect = KeyError("full_name")
-    
-    response, status_code = user_controller.register({})
-    data = json.loads(response.data)
+    response, status_code = controller.register({})
+    json_data = response.get_json()
 
     assert status_code == 400
-    
-    # =====================================================================
-    #  INÍCIO DA CORREÇÃO 1: Verificação robusta da mensagem de erro
-    # =====================================================================
-    assert "Campo obrigatório ausente" in data['error']
-    assert "full_name" in data['error']
-    # =====================================================================
-    #  FIM DA CORREÇÃO 1
-    # =====================================================================
+    assert "Campo obrigatório ausente" in json_data["error"]
 
-def test_register_value_error_returns_400(user_controller, mock_service):
-    mock_service.register.side_effect = ValueError("Formato de email inválido.")
-    complete_data = {"full_name": "Test User", "email": "invalid", "password": "password123"}
-    response, status_code = user_controller.register(complete_data)
-    data = json.loads(response.data)
+def test_register_value_error_returns_400(controller, mock_service):
+    mock_service.register.side_effect = ValueError("Email inválido.")
+    data = {"full_name": "Test", "email": "invalid", "password": "123"}
+    response, status_code = controller.register(data)
+    json_data = response.get_json()
+
     assert status_code == 400
-    assert "Formato de email inválido." in data['error']
+    assert "Email inválido." in json_data["error"]
 
-def test_register_email_in_use_error_returns_409(user_controller, mock_service):
+def test_register_email_in_use_error_returns_409(controller, mock_service):
     mock_service.register.side_effect = EmailInUseError("E-mail já cadastrado")
-    complete_data = {"full_name": "Test User", "email": "test@example.com", "password": "password123"}
-    response, status_code = user_controller.register(complete_data)
-    data = json.loads(response.data)
+    data = {"full_name": "Test", "email": "test@example.com", "password": "123"}
+    response, status_code = controller.register(data)
+    json_data = response.get_json()
+
     assert status_code == 409
-    assert "E-mail já cadastrado" in data['error']
+    assert "E-mail já cadastrado" in json_data["error"]
 
 @patch('app.controllers.user_controller.logging')
-def test_register_unexpected_exception_returns_500(mock_logging, user_controller, mock_service):
+def test_register_unexpected_exception_returns_500(mock_logging, controller, mock_service):
     mock_service.register.side_effect = Exception("Database is down")
-    complete_data = {"full_name": "Test User", "email": "test@example.com", "password": "password123"}
-    response, status_code = user_controller.register(complete_data)
-    data = json.loads(response.data)
-    assert status_code == 500
-    assert "Erro interno do servidor." in data['message']
+    data = {"full_name": "Test", "email": "test@example.com", "password": "123"}
+    response, status_code = controller.register(data)
+    json_data = response.get_json()
 
-# --- Testes de Login ---
+    assert status_code == 500
+    assert "Erro interno do servidor." in json_data["message"]
 
 @patch('app.controllers.user_controller.create_access_token', return_value="dummy_token")
 @patch('app.controllers.user_controller.set_access_cookies')
-def test_login_successfully(mock_set_cookies, mock_create_token, user_controller, mock_service):
+def test_login_successfully(mock_set_cookies, mock_create_token, controller, mock_service):
     user_obj = AttrDict({"id": 1, "full_name": "Test User", "email": "test@example.com"})
     mock_service.login.return_value = user_obj
-
-    response, status_code = user_controller.login({"email": "test@example.com", "password": "password"})
-    data = json.loads(response.data)
+    response, status_code = controller.login({"email": "test@example.com", "password": "password"})
+    json_data = response.get_json()
 
     assert status_code == 200
-    assert data['success'] is True
-    
-    response_user_data = data['data']
-    assert response_user_data['full_name'] == user_obj.full_name
-    assert response_user_data['email'] == user_obj.email
-    
+    assert json_data["success"] is True
     mock_create_token.assert_called_once_with(identity='1')
     mock_set_cookies.assert_called_once()
 
-def test_login_invalid_credentials_returns_401(user_controller, mock_service):
+def test_login_invalid_credentials_returns_401(controller, mock_service):
     mock_service.login.return_value = None
-    response, status_code = user_controller.login({"email": "test@example.com", "password": "wrongpassword"})
+    response, status_code = controller.login({"email": "test@example.com", "password": "wrongpassword"})
     assert status_code == 401
-    
-def test_login_missing_fields_returns_400(user_controller, mock_service):
-    mock_service.login.side_effect = KeyError("password")
-    
-    response, status_code = user_controller.login({"email": "test@example.com"})
-    data = json.loads(response.data)
-    
-    assert status_code == 400
-    
-    # =====================================================================
-    #  INÍCIO DA CORREÇÃO 2: Verificação robusta da mensagem de erro
-    # =====================================================================
-    assert "Dados de login inválidos ou ausentes" in data['error']
-    assert "password" in data['error']
-    # =====================================================================
-    #  FIM DA CORREÇÃO 2
-    # =====================================================================
 
-# --- Demais Testes ---
+def test_login_missing_fields_returns_400(controller, mock_service):
+    mock_service.login.side_effect = KeyError("password")
+    response, status_code = controller.login({"email": "test@example.com"})
+    json_data = response.get_json()
+
+    assert status_code == 400
+    assert "Dados de login inválidos ou ausentes" in json_data["error"]
 
 @patch('app.controllers.user_controller.logging')
-def test_login_unexpected_exception_returns_500(mock_logging, user_controller, mock_service):
+def test_login_unexpected_exception_returns_500(mock_logging, controller, mock_service):
     mock_service.login.side_effect = Exception("DB connection error")
-    response, status_code = user_controller.login({"email": "test@example.com", "password": "password"})
+    response, status_code = controller.login({"email": "test@example.com", "password": "password"})
     assert status_code == 500
 
-def test_get_profile_user_not_found_returns_404(user_controller, mock_service):
+def test_get_profile_user_not_found_returns_404(controller, mock_service):
     mock_service.get_profile.return_value = None
-    response, status_code = user_controller.get_profile(user_id=999)
+    response, status_code = controller.get_profile(user_id=999)
     assert status_code == 404
 
-def test_update_profile_user_not_found_returns_404(user_controller, mock_service):
+def test_update_profile_user_not_found_returns_404(controller, mock_service):
     mock_service.update_profile.side_effect = UserNotFoundError("Usuário não encontrado")
-    response, status_code = user_controller.update_profile(user_id=999, data={})
+    response, status_code = controller.update_profile(user_id=999, data={})
     assert status_code == 404
 
-def test_update_profile_email_in_use_returns_409(user_controller, mock_service):
+def test_update_profile_email_in_use_returns_409(controller, mock_service):
     mock_service.update_profile.side_effect = EmailInUseError("O novo e-mail já está em uso.")
-    response, status_code = user_controller.update_profile(user_id=1, data={})
+    response, status_code = controller.update_profile(user_id=1, data={})
     assert status_code == 409
 
-def test_update_profile_validation_error_returns_400(user_controller, mock_service):
+def test_update_profile_validation_error_returns_400(controller, mock_service):
     mock_service.update_profile.side_effect = ValueError("Formato de email inválido.")
-    response, status_code = user_controller.update_profile(user_id=1, data={})
+    response, status_code = controller.update_profile(user_id=1, data={})
     assert status_code == 400
 
-def test_update_password_user_not_found_returns_404(user_controller, mock_service):
+def test_update_password_user_not_found_returns_404(controller, mock_service):
     mock_service.change_password.side_effect = UserNotFoundError("Usuário não encontrado.")
-    response, status_code = user_controller.update_password(user_id=999, data={})
+    response, status_code = controller.update_password(user_id=999, data={})
     assert status_code == 404
 
-def test_update_password_validation_error_returns_400(user_controller, mock_service):
+def test_update_password_validation_error_returns_400(controller, mock_service):
     mock_service.change_password.side_effect = ValueError("A senha deve ter no mínimo 8 caracteres.")
-    response, status_code = user_controller.update_password(user_id=1, data={})
+    response, status_code = controller.update_password(user_id=1, data={})
     assert status_code == 400
+
+@patch('app.controllers.user_controller.unset_jwt_cookies')
+def test_logout_sucessfully(mock_unset_cookies, controller):
+    user_id = 1
+    response, status_code = controller.logout(user_id)
+    json_data = response.get_json()
+
+    assert status_code == 200
+    assert json_data["success"] is True
+    assert "Logout bem-sucedido" in json_data["message"]
+    mock_unset_cookies.assert_called_once_with(response)

--- a/backend/tests/test_user_news_source_repository.py
+++ b/backend/tests/test_user_news_source_repository.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import patch
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from app.repositories.user_news_source_repository import UserNewsSourceRepository
+from app.models.exceptions import NewsSourceAlreadyAttachedError, NewsSourceNotAttachedError
+from app.entities.user_news_sources_entity import UserNewsSourceEntity
+
+@pytest.fixture
+def user_news_source_repo(db):
+    return UserNewsSourceRepository(session=db.session)
+
+def test_attach_success(user_news_source_repo, db):
+    user_id, source_id = 1, 1
+    user_news_source_repo.attach(user_id, source_id)
+    relation = db.session.query(UserNewsSourceEntity).filter_by(user_id=user_id, source_id=source_id).one()
+    assert relation is not None
+
+def test_attach_already_exists_raises_error(user_news_source_repo, db):
+    user_id, source_id = 1, 1
+    user_news_source_repo.attach(user_id, source_id)
+    with pytest.raises(NewsSourceAlreadyAttachedError):
+        user_news_source_repo.attach(user_id, source_id)
+
+def test_attach_integrity_error(user_news_source_repo, db):
+    with patch.object(db.session, 'commit', side_effect=IntegrityError(None, None, None)):
+        with pytest.raises(IntegrityError):
+            user_news_source_repo.attach(1, 999) # Assuming source 999 does not exist
+
+def test_attach_sqlalchemy_error(user_news_source_repo, db):
+    with patch.object(db.session, 'commit', side_effect=SQLAlchemyError("DB Error")):
+        with pytest.raises(SQLAlchemyError):
+            user_news_source_repo.attach(1, 1)
+
+def test_detach_success(user_news_source_repo, db):
+    user_id, source_id = 1, 1
+    db.session.add(UserNewsSourceEntity(user_id=user_id, source_id=source_id))
+    db.session.commit()
+
+    user_news_source_repo.detach(user_id, source_id)
+
+    relation = db.session.query(UserNewsSourceEntity).filter_by(user_id=user_id, source_id=source_id).first()
+    assert relation is None
+
+def test_detach_not_existing_raises_error(user_news_source_repo):
+    with pytest.raises(NewsSourceNotAttachedError):
+        user_news_source_repo.detach(1, 999)
+
+def test_detach_sqlalchemy_error(user_news_source_repo, db):
+    user_id, source_id = 1, 1
+    db.session.add(UserNewsSourceEntity(user_id=user_id, source_id=source_id))
+    db.session.commit()
+
+    with patch.object(db.session, 'commit', side_effect=SQLAlchemyError("DB Error")):
+        with pytest.raises(SQLAlchemyError):
+            user_news_source_repo.detach(user_id, source_id)
+
+def test_attach_logs_and_raises_on_integrity_error(user_news_source_repo):
+    with patch('app.repositories.user_news_source_repository.logging') as mock_logging:
+        with patch.object(user_news_source_repo.session, 'commit', side_effect=IntegrityError(None, None, None)):
+            with pytest.raises(IntegrityError):
+                user_news_source_repo.attach(1, 1)
+            mock_logging.warning.assert_called_once()

--- a/backend/tests/test_user_service.py
+++ b/backend/tests/test_user_service.py
@@ -164,7 +164,6 @@ def test_login_missing_fields_raises_error(user_service):
         
     assert "E-mail e senha são obrigatórios." in str(e.value)
 
-# Testes para o método get_profile
 def test_get_profile_successful(user_service, mock_user_repo, test_user_data):
     user_id = 1
     user_model_in_db = User(
@@ -189,8 +188,7 @@ def test_get_profile_user_not_found(user_service, mock_user_repo):
     
     assert profile is None
     mock_user_repo.find_by_id.assert_called_once_with(user_id)
-
-# Testes para o método update_profile
+    
 def test_update_profile_successful(user_service, mock_user_repo, test_user_data):
     user_id = 1
     user_model_in_db = User(
@@ -294,7 +292,6 @@ def test_update_profile_invalid_value_raises_error(user_service, mock_user_repo,
     mock_user_repo.find_by_email.assert_not_called()
     mock_user_repo.update.assert_not_called()
 
-# Testes para o método change_password
 def test_change_password_successful(user_service, mock_user_repo, test_user_data):
     user_id = 1
     user_model_in_db = User(

--- a/test_news_source_controller.py
+++ b/test_news_source_controller.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from flask import Flask, jsonify
+from sqlalchemy.exc import IntegrityError
+from backend.app.controllers.news_source_controller import NewsSourceController
+from backend.app.models.news_source import NewsSource
+from backend.app.models.exceptions import NewsSourceNotFoundError, NewsSourceAlreadyAttachedError, NewsSourceNotAttachedError
+
+@pytest.fixture
+def mock_service():
+    with patch('backend.app.controllers.news_source_controller.NewsSourceService') as mock:
+        yield mock.return_value
+
+@pytest.fixture
+def app_context():
+    app = Flask(__name__)
+    with app.app_context():
+        yield
+
+@pytest.fixture
+def controller(mock_service, app_context):
+    c = NewsSourceController()
+    c.service = mock_service
+    return c
+
+def test_list_all_success(controller, mock_service):
+    sources = [NewsSource(id=1, name="Test Source", url="http://test.com")]
+    mock_service.list_all.return_value = sources
+    response, status_code = controller.list_all()
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_exception(controller, mock_service):
+    mock_service.list_all.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all()
+    assert status_code == 500
+    assert response.json["success"] is False
+    assert "Erro interno do servidor" in response.json["message"]
+
+def test_list_all_unattached_success(controller, mock_service):
+    user_id = 1
+    sources = [NewsSource(id=2, name="Unattached", url="http://unattached.com")]
+    mock_service.list_unassociated_by_user_id.return_value = sources
+    response, status_code = controller.list_all_unattached_news_sources(user_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_unattached_exception(controller, mock_service):
+    user_id = 1
+    mock_service.list_unassociated_by_user_id.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all_unattached_news_sources(user_id)
+    assert status_code == 500
+    assert response.json["success"] is False
+
+def test_list_all_attached_success(controller, mock_service):
+    user_id = 1
+    sources = [NewsSource(id=3, name="Attached", url="http://attached.com")]
+    mock_service.list_by_user_id.return_value = sources
+    response, status_code = controller.list_all_attached_sources(user_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    assert len(response.json["data"]) == 1
+
+def test_list_all_attached_exception(controller, mock_service):
+    user_id = 1
+    mock_service.list_by_user_id.side_effect = Exception("DB Error")
+    response, status_code = controller.list_all_attached_sources(user_id)
+    assert status_code == 500
+    assert response.json["success"] is False
+
+def test_attach_success(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.return_value = None
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 200
+    assert response.json["success"] is True
+    mock_service.attach_source_to_user.assert_called_once_with(user_id, 10)
+
+def test_attach_missing_source_id(controller):
+    user_id = 1
+    data = {}
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "source_id é obrigatório" in response.json["error"]
+
+def test_attach_invalid_source_id(controller):
+    user_id = 1
+    data = {"source_id": "abc"}
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "deve ser um número inteiro válido" in response.json["error"]
+
+def test_attach_source_not_found(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 999}
+    mock_service.attach_source_to_user.side_effect = NewsSourceNotFoundError("Not Found")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 404
+    assert "Not Found" in response.json["error"]
+
+def test_attach_already_attached(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = NewsSourceAlreadyAttachedError("Conflict")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 409
+    assert "Conflict" in response.json["error"]
+
+def test_attach_integrity_error(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = IntegrityError(None, None, None)
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 400
+    assert "Falha de integridade" in response.json["message"]
+
+def test_attach_generic_exception(controller, mock_service):
+    user_id = 1
+    data = {"source_id": 10}
+    mock_service.attach_source_to_user.side_effect = Exception("Generic Error")
+    response, status_code = controller.attach_news_source(user_id, data)
+    assert status_code == 500
+    assert "Erro interno do servidor" in response.json["message"]
+
+def test_detach_success(controller, mock_service):
+    user_id = 1
+    source_id = 10
+    mock_service.detach_source_from_user.return_value = None
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 200
+    assert response.json["success"] is True
+    mock_service.detach_source_from_user.assert_called_once_with(user_id, source_id)
+
+def test_detach_not_attached(controller, mock_service):
+    user_id = 1
+    source_id = 999
+    mock_service.detach_source_from_user.side_effect = NewsSourceNotAttachedError("Not Found")
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 404
+    assert "Not Found" in response.json["error"]
+
+def test_detach_generic_exception(controller, mock_service):
+    user_id = 1
+    source_id = 10
+    mock_service.detach_source_from_user.side_effect = Exception("Generic Error")
+    response, status_code = controller.detach_news_source(user_id, source_id)
+    assert status_code == 500
+    assert "Erro interno do servidor" in response.json["message"]

--- a/test_news_source_repository.py
+++ b/test_news_source_repository.py
@@ -1,0 +1,82 @@
+import pytest
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from unittest.mock import patch
+from backend.app.repositories.news_source_repository import NewsSourceRepository
+from backend.app.models.news_source import NewsSource
+from backend.app.entities.user_entity import UserEntity
+from backend.app.entities.news_source_entity import NewsSourceEntity
+from backend.app.entities.user_news_sources_entity import UserNewsSourceEntity
+
+@pytest.fixture
+def news_source_repo(db):
+    return NewsSourceRepository(session=db.session)
+
+def test_create_news_source_success(news_source_repo):
+    source_model = NewsSource(name="Test Source", url="http://testsource.com")
+    created_source = news_source_repo.create(source_model)
+    assert created_source.id is not None
+    assert created_source.name == "Test Source"
+
+def test_create_duplicate_url_fails(news_source_repo):
+    source1 = NewsSource(name="Source One", url="http://duplicate.com")
+    news_source_repo.create(source1)
+    source2 = NewsSource(name="Source Two", url="http://duplicate.com")
+    with pytest.raises(IntegrityError):
+        news_source_repo.create(source2)
+
+def test_find_by_id(news_source_repo, db):
+    source_entity = NewsSourceEntity(name="Find Me", url="http://findme.com")
+    db.session.add(source_entity)
+    db.session.commit()
+    found = news_source_repo.find_by_id(source_entity.id)
+    assert found is not None
+    assert found.id == source_entity.id
+
+def test_find_by_url(news_source_repo, db):
+    source_entity = NewsSourceEntity(name="Find By URL", url="http://findbyurl.com")
+    db.session.add(source_entity)
+    db.session.commit()
+    found = news_source_repo.find_by_url("http://findbyurl.com")
+    assert found is not None
+    assert found.url == "http://findbyurl.com"
+
+def test_list_all(news_source_repo, db):
+    db.session.add(NewsSourceEntity(name="A", url="http://a.com"))
+    db.session.add(NewsSourceEntity(name="B", url="http://b.com"))
+    db.session.commit()
+    sources = news_source_repo.list_all()
+    assert len(sources) == 2
+
+def test_list_by_user_id(news_source_repo, db):
+    user = UserEntity(email="user@test.com", _password_hash="hash")
+    s1 = NewsSourceEntity(name="S1", url="http://s1.com")
+    s2 = NewsSourceEntity(name="S2", url="http://s2.com")
+    db.session.add_all([user, s1, s2])
+    db.session.commit()
+    db.session.add(UserNewsSourceEntity(user_id=user.id, source_id=s1.id))
+    db.session.commit()
+    
+    user_sources = news_source_repo.list_by_user_id(user.id)
+    assert len(user_sources) == 1
+    assert user_sources[0].name == "S1"
+
+def test_list_unassociated_by_user_id(news_source_repo, db):
+    user = UserEntity(email="user2@test.com", _password_hash="hash")
+    s1 = NewsSourceEntity(name="S1-un", url="http://s1un.com")
+    s2 = NewsSourceEntity(name="S2-un", url="http://s2un.com") 
+    s3 = NewsSourceEntity(name="S3-un", url="http://s3un.com") 
+    db.session.add_all([user, s1, s2, s3])
+    db.session.commit()
+    db.session.add(UserNewsSourceEntity(user_id=user.id, source_id=s1.id))
+    db.session.commit()
+
+    unassociated = news_source_repo.list_unassociated_by_user_id(user.id)
+    assert len(unassociated) == 2
+    names = {s.name for s in unassociated}
+    assert "S2-un" in names
+    assert "S3-un" in names
+
+def test_sqlalchemy_error_on_list(news_source_repo):
+    with patch.object(news_source_repo.session, 'execute', side_effect=SQLAlchemyError("DB Error")):
+        with pytest.raises(SQLAlchemyError):
+            news_source_repo.list_all()


### PR DESCRIPTION
## Descrição
O trabalho foi dividido em duas frentes principais:
1.  **Criação de testes de unidade, integração e repositório** para toda a funcionalidade de Fontes de Notícias, que antes não possuía cobertura.
2.  **Refatoração e aprimoramento dos testes existentes** para `User`, `Topic` e `Auth`, corrigindo falhas, melhorando a estrutura das fixtures e aumentando a clareza das validações.

## Mudanças Implementadas

### 🚀 Nova Cobertura de Testes para Fontes de Notícias

Foram criados novos arquivos de teste para cobrir todas as camadas da funcionalidade de `News Source`:

-   **`test_news_source_controller.py` (Testes Unitários do Controller):**
    -   Valida a lógica do `NewsSourceController` de forma isolada.
    -   Cobre todos os cenários de sucesso, validação de dados de entrada (ID da fonte ausente ou inválido) e tratamento de exceções customizadas (`NewsSourceNotFoundError`, `NewsSourceAlreadyAttachedError`) e do banco de dados (`IntegrityError`).

-   **`test_news_source_repository.py` e `test_user_news_source_repository.py` (Testes da Camada de Repositório):**
    -   Testam diretamente a interação com o banco de dados em memória.
    -   Garantem o funcionamento das operações de `CRUD` para fontes de notícias e a lógica de `attach`/`detach` na tabela de associação.
    -   Validam o tratamento de erros de integridade, como a tentativa de criar fontes com URLs duplicadas.

-   **`test_news_source_unit.py` (Testes Unitários do Serviço e Modelo):**
    -   Valida a lógica de negócio no `NewsSourceService`, como a verificação de fontes existentes antes de criar novas.
    -   Testa as validações de dados do modelo `NewsSource`, garantindo que nomes e URLs inválidos levantem a exceção `NewsSourceValidationError`.

-   **`test_news_source_integration.py` (Testes de Integração):**
    -   Valida o fluxo completo da API, desde a requisição HTTP até a resposta, para as rotas de fontes de notícias.
    -   Testa os endpoints de associação e desassociação de fontes a um usuário autenticado, verificando o estado do banco de dados após cada operação.

### 🛠️ Refatoração e Melhorias em Testes Existentes

-   **`test_user_controller.py`:**
    -   A estrutura das `fixtures` foi completamente refatorada para garantir a correta injeção de dependências (`mock_service`), eliminando erros de contexto do Flask.
    -   Os testes foram atualizados para usar `response.get_json()`, tornando-os mais limpos.
    -   Foi adicionado o teste `test_register_success` e `test_logout_sucessfully`, cobrindo linhas que antes estavam ausentes.

-   **`test_topic_service.py`:**
    -   Foram adicionados testes para cenários complexos de `IntegrityError`, simulando *race conditions* em que o serviço tenta se recuperar de uma falha de criação, aumentando a robustez da lógica.

-   **`test_topic_routes.py`:**
    -   Os testes de rotas de tópicos foram refatorados para maior clareza e precisão, alinhando-se com as `fixtures` e helpers de autenticação.

-   **Código da Aplicação:**
    -   Pequenos ajustes foram feitos no `NewsSourceService` e nos repositórios para permitir a injeção de dependência e melhorar o tratamento de exceções, facilitando a criação dos testes.

## Como Testar

1.  **Execute a suíte de testes completa:**
    Este comando irá rodar todos os testes, incluindo os novos e os refatorados.
    ```bash
    docker compose exec backend pytest
    ```

2.  **Visualize a nova cobertura de testes:**
    Este comando irá gerar um relatório detalhado no terminal, mostrando a nova porcentagem de cobertura e destacando as poucas linhas que ainda não foram cobertas.
    ```bash
    docker compose exec backend pytest --cov=app
    ```