### PR TITLE
Feature/history read news

### DIFF
--- a/backend/app/controllers/news_controller.py
+++ b/backend/app/controllers/news_controller.py
@@ -131,3 +131,31 @@ class NewsController:
             return jsonify({"success": True, "message": "Noticia acessada.", "data": {"news_id": news_id}, "error": None}), 200
         except Exception as e:
              return jsonify({"success": False, "message": "Erro salvar acesso a noticia.", "data": None, "error": str(e)}), 500
+
+    def get_history_news(self, user_id: int):
+        try:
+            page = request.args.get('page', 1, type=int)
+            per_page = request.args.get('per_page', 10, type=int)
+            
+            if page < 1:
+                page = 1
+            if per_page < 1 or per_page > 100:
+                per_page = 10
+            
+            result = self.news_service.get_history_news(user_id, page, per_page)
+            
+            return jsonify({
+                "success": True,
+                "message": "Histórico de notícias obtido com sucesso.",
+                "data": result,
+                "error": None
+            }), 200
+            
+        except Exception as e:
+            logging.error(f"Erro ao obter histórico: {e}", exc_info=True)
+            return jsonify({
+                "success": False,
+                "message": "Erro ao buscar histórico de notícias.",
+                "data": None,
+                "error": str(e)
+            }), 500

--- a/backend/app/controllers/news_controller.py
+++ b/backend/app/controllers/news_controller.py
@@ -5,7 +5,6 @@ from app.services.news_service import NewsService
 from app.models.exceptions import NewsNotFoundError, NewsSourceAlreadyAttachedError
 from typing import Optional
 
-
 class NewsController:
     def __init__(self):
         self.user_service = UserService()
@@ -125,3 +124,10 @@ class NewsController:
                 "data": None,
                 "error": str(e)
             }), 404
+
+    def save_history_news(self, user_id:int, news_id:int):
+        try:
+            self.news_service.save_history(user_id, news_id)
+            return jsonify({"success": True, "message": "Noticia acessada.", "data": {"news_id": news_id}, "error": None}), 200
+        except Exception as e:
+             return jsonify({"success": False, "message": "Erro salvar acesso a noticia.", "data": None, "error": str(e)}), 500

--- a/backend/app/repositories/user_read_history_repository.py
+++ b/backend/app/repositories/user_read_history_repository.py
@@ -1,0 +1,59 @@
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy.orm import joinedload
+from sqlalchemy import func, select
+from datetime import datetime 
+import logging
+
+from app.extensions import db
+from app.entities.user_entity import UserEntity
+from app.entities.news_entity import NewsEntity
+from app.entities.user_read_history_entity import UserReadHistoryEntity
+from app.models.exceptions import UserNotFoundError, NewsNotFoundError
+
+class UserReadHistoryRepository:
+    def __init__(self, session=None):
+        self.session = session or db.session
+
+    def create(self, user_id: int, news_id: int) -> UserReadHistoryEntity:
+        try:
+            user_exists = self.session.query(
+                self.session.query(UserEntity).filter_by(id=user_id).exists()
+            ).scalar()
+            
+            if not user_exists:
+                raise UserNotFoundError(f"Usuário com ID {user_id} não encontrado.")
+            
+            news_exists = self.session.query(
+                self.session.query(NewsEntity).filter_by(id=news_id).exists()
+            ).scalar()
+            
+            if not news_exists:
+                raise NewsNotFoundError(f"Notícia com ID {news_id} não encontrada.")
+            
+            history_entity = UserReadHistoryEntity(
+                user_id=user_id,
+                news_id=news_id,
+                read_at=datetime.now()
+            )
+            
+            self.session.add(history_entity)
+            self.session.commit()
+            self.session.refresh(history_entity)
+            
+            logging.info(f"Histórico de leitura criado: user_id={user_id}, news_id={news_id}, read_at={history_entity.read_at}")
+            
+            return history_entity
+            
+        except (UserNotFoundError, NewsNotFoundError):
+            self.session.rollback()
+            raise
+        except IntegrityError as e:
+            self.session.rollback()
+            logging.error(f"Erro de integridade ao criar histórico: {e}", exc_info=True)
+            raise Exception("Erro de integridade ao salvar histórico de leitura.")
+        except SQLAlchemyError as e:
+            self.session.rollback()
+            logging.error(f"Erro de banco ao criar histórico: {e}", exc_info=True)
+            raise Exception("Erro ao salvar histórico de leitura no banco de dados.")
+
+   

--- a/backend/app/routes/news_routes.py
+++ b/backend/app/routes/news_routes.py
@@ -7,13 +7,23 @@ from app.routes.user_routes import get_user_id_from_token, get_optional_user_id_
 news_bp = Blueprint("news", __name__)
 news_controller = NewsController()
 
-
-
 @news_bp.route("/<int:news_id>", methods=["GET"])
 @jwt_required(optional=True)
 @get_optional_user_id_from_token
 def get_news_by_id(user_id, news_id: int):
     return news_controller.get_by_id(user_id, news_id)
+
+@news_bp.route("/<int:news_id>/history", methods=["POST"])
+@jwt_required()
+@get_user_id_from_token
+def save_history_news(user_id: int, news_id: int):
+    return news_controller.save_history_news(user_id, news_id)
+
+@news_bp.route("/history", methods=["GET"])
+@jwt_required()
+@get_user_id_from_token
+def get_history_news(user_id: int):
+    return news_controller.get_for_you_news(user_id)
 
 @news_bp.route("/<int:news_id>/favorite", methods=["POST"])
 @jwt_required()

--- a/backend/app/routes/news_routes.py
+++ b/backend/app/routes/news_routes.py
@@ -23,7 +23,7 @@ def save_history_news(user_id: int, news_id: int):
 @jwt_required()
 @get_user_id_from_token
 def get_history_news(user_id: int):
-    return news_controller.get_for_you_news(user_id)
+    return news_controller.get_history_news(user_id)
 
 @news_bp.route("/<int:news_id>/favorite", methods=["POST"])
 @jwt_required()


### PR DESCRIPTION
## ✨ Feature: Histórico de Notícias Lidas

**Descrição:**
Esta implementação introduz a funcionalidade de rastreamento do histórico de leitura de notícias pelo usuário. Foram adicionados endpoints para registrar uma notícia como lida e para recuperar a lista de notícias que o usuário já consumiu.

---

## 🛠 O Que Foi Implementado?

*Liste as principais alterações técnicas:*

- [x] **Criação do Modelo/Tabela:** Implementação da nova tabela pivot (`user_news_history` ou similar) para mapear o vínculo $Usuário \leftrightarrow Notícia$.
- [x] **Endpoint `POST /news/{newsId}/history`:** Adicionado endpoint para registrar uma notícia específica como lida pelo usuário autenticado.
    * **Comportamento:** Cria o registro de vínculo na nova tabela.
- [x] **Endpoint `GET /news/history`:** Adicionado endpoint para buscar e listar todas as notícias lidas pelo usuário autenticado.
    * **Comportamento:** Consulta a tabela de histórico e retorna os dados das notícias lidas.
- [x] **Camadas de Serviço e Persistência:** Lógica implementada nos *Services* e *Repositories* para lidar com as operações de gravação e consulta do histórico.
- [x] **Segurança:** Ambos os endpoints estão protegidos por autenticação JWT (`@jwt_required()`).

---

## 🧪 Como Testar (Via Postman)

Siga os passos abaixo para verificar o registro e a recuperação do histórico.

### Pré-requisitos

1.  Um usuário cadastrado.
2.  Pelo menos um `newsId` válido (ID de uma notícia existente).

### Passo a Passo

1.  **Autenticação:**
    * **Rota:** `POST /users/login`
    * Obtenha o **Token JWT** na resposta.
    * Configure o token no *Header* de todas as requisições subsequentes: `Authorization: Bearer <seu_token>`.

2.  **Registrar Leitura (POST):**
    * **Método:** `POST`
    * **Rota:** `/news/{newsId}/history` (Ex: `/news/b9a3f2d1-0f4c-4e8b-a2c3-5d6e7f8g9h0i/history`)
    * **Ação Esperada:** A requisição deve retornar `201 Created` (ou `200 OK` se a notícia já havia sido lida) e salvar o registro no banco.

3.  **Consultar Histórico (GET):**
    * **Método:** `GET`
    * **Rota:** `/news/history`
    * **Ação Esperada:** A requisição deve retornar `200 OK` com um corpo JSON contendo a notícia registrada no Passo 2 dentro da lista de `data`.

4.  **Verificação de Conteúdo:** Verifique se a lista retornada no `GET` reflete exatamente o que foi salvo via `POST`.